### PR TITLE
Fix unexpected bye by skipping emoji

### DIFF
--- a/tests/timesheets_test.js
+++ b/tests/timesheets_test.js
@@ -180,21 +180,21 @@ QUnit.test( "Timesheets", function(assert) {
   });
 
   // 休憩時間(稼働中)
-  test1 = {};
+  var test1 = {};
   test1[nowDateStr()] = { user: 'test1', signIn: new Date(2014,0,2,5,0,0), signOut: '-' };
   storageTest({'test1': test1}, function(msgTest) {
     msgTest('test1', '休憩 30分', [['休憩', 'test1', "30分"]]);
   });
 
   // 休憩時間(稼働中、絵文字付き)
-  test1 = {};
+  var test1 = {};
   test1[nowDateStr()] = { user: 'test1', signIn: new Date(2014,0,2,5,0,0), signOut: '-' };
   storageTest({'test1': test1}, function(msgTest) {
     msgTest('test1', '休憩 30分 (:curry:)', [['休憩', 'test1', "30分"]]);
   });
 
   // 休憩時間(退勤後)
-  test1 = {};
+  var test1 = {};
   test1[nowDateStr()] = { user: 'test1', signIn: new Date(2014,0,2,5,0,0), signOut: new Date(2014,0,2,12,0,0) };
   storageTest({'test1': test1}, function(msgTest) {
     msgTest('test1', '休憩 30分', [['休憩', 'test1', "30分"]]);


### PR DESCRIPTION
Fixes #61.

Changes proposed in this pull request:
- Add failed test case with emoji
  - commit: https://github.com/Georepublic/miyamoto/pull/64/commits/91e9d10b5f4d64edcd64f3e6f85039cab898ea22
- Remove emoji when finding command
  - commit: https://github.com/Georepublic/miyamoto/pull/64/commits/7d37d5071f478937ec8a9557bd387165c87c3415
  - Use the following Stack Overflow article's 1st answer's RegExp patter.
    - [javascript - Regex to find and replace emoji names within colons - Stack Overflow](https://stackoverflow.com/questions/49745304/regex-to-find-and-replace-emoji-names-within-colons)
- Modify replaceAll to replace for Node.js < 15 env
  - commit: https://github.com/Georepublic/miyamoto/pull/64/commits/ae3a8fca5dc2f8cce3e33a9669ba709429502117
  - [Node.jsで”replaceAll is not a function”エラー - プログラミングの「YUIPRO」](https://yuis-programming.com/?p=3293)

@Georepublic/maintainer
